### PR TITLE
Added IPv6 support (required ipv6calc package)

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -1,52 +1,74 @@
 #!/bin/bash
-
+#
+# MIT License
+#
+# Copyright (c) Intellex 2015
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 # =============================================================================
 #
 # title             : blcheck
 # description       : Test any domain against more than 100 blocklists.
 # author            : Intellex
 # contributors      : Darko Poljak, Oliver Mueller, Andrej Walilko
-# date              : Sep 15 2020
-# version           : 0.7.6
+# date              : Sep 22 2021
+# version           : 0.7.7
 # usage             : blcheck [options] <domain_or_ip>
 # reference         : http://multirbl.valli.org/list/
 # code style        : https://google.github.io/styleguide/shell.xml
 # url               : github.com/ch604/blcheck
-#
-# =============================================================================
+
+# ============================================================================
 
 # Config {
-    # where to log blocklist hits permanently if there are any
-    # this file will be appended, not clobbered.
-    # format is ${TARGET}\n$blocklist1\n$blocklist2, etc
-    output=~/blcheck_blocklists.txt
+# where to log blocklist hits permanently if there are any
+# this file will be appended, not clobbered.
+# format is ${TARGET}\n$blocklist1\n$blocklist2, etc
+OUTPUT=~/blcheck_blocklists.txt
 
-    # how many dig/host processes to run in parallel
-    # this can be a number of threads (6)
-    # or a percentage of cpu cores (75%)
-    j="200%"
+# how many dig/host processes to run in parallel
+# this can be a number of threads (6)
+# or a percentage of cpu cores (75%)
+PARALLEL_JOB="200%"
 
-    # How many tries and for how long to wait for DNS queries
-    CONF_DNS_TRIES=2
-    CONF_DNS_DURATION=3
+# How many tries and for how long to wait for DNS queries
+CONF_DNS_TRIES=2
+CONF_DNS_DURATION=3
 
-    # Blacklists to check
-    # Example formats:
-    # - General format
-    #   {ip_or_domain}={filter}#{type}
-    # - IP based blocklist (default DNSBL, any valid return code will match)
-    #   block.list.com
-    # - IP based blocklist
-    #   block.list.com#DNSBL
-    # - IP based allowlist
-    #   allow.list.com#DNSWL
-    # - URI based blocklist
-    #   uri.list.com#URIBL
-    # - Regexp defined return code, only a match will qualify for list. Here it is 127.0.0.2 and 127.0.0.3
-    #   block.list.com=127\.0\.0\.[23]
-    # - Regexp defined return code for a URI based blocklist
-    #   block.list.com=127\.0\.[0-9]+\.0#URIBL
-    CONF_BLACKLISTS="
+# Blacklists to check
+# Example formats:
+# - General format
+#   {ip_or_domain}={filter}#{type}
+# - IP based blocklist (default DNSBL, any valid return code will match)
+#   block.list.com
+# - IP based blocklist
+#   block.list.com#DNSBL
+# - IP based allowlist
+#   allow.list.com#DNSWL
+# - URI based blocklist
+#   uri.list.com#URIBL
+# - Regexp defined return code, only a match will qualify for list. Here it is 127.0.0.2 and 127.0.0.3
+#   block.list.com=127\.0\.0\.[23]
+# - Regexp defined return code for a URI based blocklist
+#   block.list.com=127\.0\.[0-9]+\.0#URIBL
+CONF_BLACKLISTS="
         whitelist.rbl.ispa.at#DNSWL
         t3direct.dnsbl.net.au
         ucepn.dnsbl.net.au
@@ -378,150 +400,192 @@
         bsb.empty.us
         88.blocklist.zap"
 
+# reputation/scoring pages
+# score.senderscore.com
 
-        # reputation/scoring pages
-        # score.senderscore.com
-
-    CONF_BLACKLISTS_TEST="
-        rbl.rbldns.ru
-        rbl.rbldns.ru=127\.0\.0\.1
-        rbl.rbldns.ru#DNSWL
-        black.list.com=127.0.[0-9]+.0#URIBL
-        dbl.spamhaus.org#URIBL
-        t3direct.dnsbl.net.au=127\.0\.0\.1#DNSWL
-        t3direct.dnsbl.net.au#BLA
-        t3direct.dnsbl.net.au%127\.0\.0\.1#DNSWL"
-
+#CONF_BLACKLISTS_TEST="
+#        rbl.rbldns.ru
+#        rbl.rbldns.ru=127\.0\.0\.1
+#        rbl.rbldns.ru#DNSWL
+#        black.list.com=127.0.[0-9]+.0#URIBL
+#        dbl.spamhaus.org#URIBL
+#        t3direct.dnsbl.net.au=127\.0\.0\.1#DNSWL
+#        t3direct.dnsbl.net.au#BLA
+#        t3direct.dnsbl.net.au%127\.0\.0\.1#DNSWL"
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
 
 # Definitions {
 
-    # Common regular expressions
-    REGEX_IP='\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)'
-    REGEX_DOMAIN='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)\+[a-zA-Z]\{2,\}'
-    REGEX_TDL='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$'
-    REGEX_LIST='^[ \\t]*([^=#]+)(=(([^#])+))?(#(DNSBL|DNSWL|URIBL))?[ \\t]*$'
+# Common regular expressions
+REGEX_IP='\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)'
+REGEX_IPV6='\([0-9a-fA-F]\{0,4\}:\)\{1,7\}[0-9a-fA-F]\{0,4\}'
+REGEX_DOMAIN='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)\+[a-zA-Z]\{2,\}'
+#REGEX_TDL='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$'
+REGEX_LIST='^[ \\t]*([^=#]+)(=(([^#])+))?(#(DNSBL|DNSWL|URIBL))?[ \\t]*$'
 
-    # Colors
-    if [[ $- == *i* ]]; then
-        RED=$(tput setaf 1)
-        GREEN=$(tput setaf 2)
-        YELLOW=$(tput setaf 3)
-        CLEAR=$(tput sgr0)
-    else
-        RED=$(tput -T xterm setaf 1)
-        GREEN=$(tput -T xterm setaf 2)
-        YELLOW=$(tput -T xterm setaf 3)
-        CLEAR=$(tput -T xterm sgr0)
-    fi
+# Colors
+if [[ $- == *i* ]]; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  YELLOW=$(tput setaf 3)
+  CLEAR=$(tput sgr0)
+else
+  RED=$(tput -T xterm setaf 1)
+  GREEN=$(tput -T xterm setaf 2)
+  YELLOW=$(tput -T xterm setaf 3)
+  CLEAR=$(tput -T xterm sgr0)
+fi
 
-    # Define spinner
-    SPINNER="-\|/"
-    #SPINNER=".oO@*"
-    #SPINNER="▉▊▋▌▍▎▏▎▍▌▋▊▉"
-    #SPINNER="←↖↑↗→↘↓↙"
-    #SPINNER="▁▂▃▄▅▆▇█▇▆▅▄▃▁"
-    #SPINNER="▖▘▝▗"
-    #SPINNER="┤┘┴└├┌┬┐"
-    #SPINNER="◢◣◤◥"
-    #SPINNER="◰◳◲◱"
-    #SPINNER="◴◷◶◵"
-    #SPINNER="◐◓◑◒"
+# Define spinner
+SPINNER="-\|/"
+#SPINNER=".oO@*"
+#SPINNER="▉▊▋▌▍▎▏▎▍▌▋▊▉"
+#SPINNER="←↖↑↗→↘↓↙"
+#SPINNER="▁▂▃▄▅▆▇█▇▆▅▄▃▁"
+#SPINNER="▖▘▝▗"
+#SPINNER="┤┘┴└├┌┬┐"
+#SPINNER="◢◣◤◥"
+#SPINNER="◰◳◲◱"
+#SPINNER="◴◷◶◵"
+#SPINNER="◐◓◑◒"
 
-    VERBOSE=0
+VERBOSE=0
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
 
 # Macros {
 
-    # Verbose printing
-    info() {
-        if [[ ${VERBOSE} -ge "$1" ]]; then
-            echo "$2"
+# Verbose printing
+info() {
+  if [[ ${VERBOSE} -ge "$1" ]]; then
+    echo "$2"
+  fi
+}
+
+# Error handling
+error() {
+  echo "ERROR: $1" >&2
+  exit 254
+}
+
+# Show progress
+progress() {
+  local BAR x
+  # Bar
+  x=$(($1 % ${#SPINNER} + 1))
+  BAR=$(echo ${SPINNER} | awk "{ print substr(\$0, ${x}, 1) }")
+  if [[ -z "${PLAIN}" ]]; then
+    printf "\r "
+  fi
+
+  # BAR as printf arg so that backslash will be literally interpreted
+  printf "[ %s %3s%% ] checking... %4s / $2  " "${BAR}" $(($1 * 100 / $2)) "$1"
+}
+
+reverseIPv6() {
+  echo "$1" | awk -F: 'BEGIN {OFS=""; }{addCount = 9 - NF; for(i=1; i<=NF;i++){if(length($i) == 0){ for(j=1;j<=addCount;j++){$i = ($i "0000");} } else { $i = substr(("0000" $i), length($i)+5-4);}}; print}' | rev |  sed -e "s/./&./g;s/.$//"
+}
+reverseIPv4() {
+  echo "$1" | sed -r 's/([0-9]{1,3}).([0-9]{1,3}).([0-9]{1,3}).([0-9]{1,3})/\4.\3.\2.\1/'
+}
+
+# Resolve the IP
+resolve() {
+
+  local IP TYPE
+
+  IP="$1"
+
+  # IPv4?
+  if ipv6calc -qI ipv4addr "${IP}" &>/dev/null; then
+    echo "${IP}"
+  # IPv6?
+  elif ipv6calc -qI ipv6addr "${IP}" &>/dev/null; then
+    # Convert to full form before reversing
+    IP="$(ipv6calc -q --addr2fulluncompaddr "${IP}")"
+    echo "${IP}"
+    # Resolve domain
+  else
+    HOST="$1"
+    # Handle special resolve types
+    case "$2" in
+    "ns")
+      TYPE="ns"
+      REGEX="${REGEX_DOMAIN}\.$"
+      ;;
+    *)
+      TYPE="a"
+      REGEX="${REGEX_IP}$"
+      ;;
+    esac
+
+    case "${CMD}" in
+    "${CMD_DIG}")
+      IP=$("${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "${HOST}" | grep -om 1 "${REGEX}")
+      if [ -n "${IP}" ]; then
+        echo "${IP}"
+      else
+        IP=$("${CMD}" ${DNSSERVER} +short -t "aaaa" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "${HOST}" | grep -om 1 "${REGEX_IPV6}")
+
+        if [ -n "${IP}" ]; then
+          echo "${IP}"
         fi
-    }
+      fi
 
-    # Error handling
-    error() {
-        echo "ERROR: $1" >&2
-        exit 254
-    }
+      ;;
+    "${CMD_HOST}")
+      IP=$("${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "${HOST}" ${DNSSERVER} | tail -n1 | grep -om 1 "${REGEX}")
+      if [ -n "${IP}" ]; then
+        echo "${IP}"
+      else
+        IP=$("${CMD}" -t "aaaa" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "${HOST}" ${DNSSERVER} | tail -n1 | grep -om 1 "${REGEX_IPV6}")
 
-    # Show progress
-    progress() {
-
-        # Bar
-        local x=$(($1 % ${#SPINNER} + 1))
-        local BAR=$(echo ${SPINNER} | awk "{ print substr(\$0, ${x}, 1) }")
-        if [[ -z "${PLAIN}" ]]; then
-            printf "\r ";
+        if [ -n "${IP}" ]; then
+          echo "${IP}"
         fi
+      fi
+      ;;
+    esac
+  fi
+}
 
-        # BAR as printf arg so that backslash will be litteraly interpreted
-        printf "[ %s %3s%% ] checking... %4s / $2  " "${BAR}" $(($1 * 100 / $2)) "$1";
-    }
+# Result info for IP
+text() {
+  local IP
+  # IP already?
+  IP=$(echo "$1" | grep "^${REGEX_IP}$")
+  if [[ -n "${IP}" ]]; then
+    echo "${IP}"
 
-    # Resolve the IP
-    resolve() {
+  # Resolve domain
+  else
+    local TYPE="txt"
+    case "${CMD}" in
+    "${CMD_DIG}") "${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "$1" ;;
+    "${CMD_HOST}") "${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "$1" ${DNSSERVER} | tail -n1 ;;
+    esac
+  fi
+}
 
-        # IP already?
-        local IP=$(echo "$1" | grep "^${REGEX_IP}$")
-        if [[ "${IP}" ]]; then
-            echo "${IP}"
+# Load the blocklist from file
+loadBlacklists() {
 
-        # Resolve domain
-        else
+  # Make sure the file is readable
+  if [[ -z "$1" ]]; then
+    error "Option -l requires an additional parameter"
+  elif [[ ! -r $1 ]]; then
+    error "File $1 cannot be opened for reading, make sure it exists and that you have appropriate privileges"
+  fi
 
-            # Handle special resolve types
-            case "$2" in
-                "ns" ) TYPE="ns"; REGEX="${REGEX_DOMAIN}\.$";;
-                   * ) TYPE="a";  REGEX="${REGEX_IP}$";;
-            esac
+  CONF_BLACKLISTS=$(cat "$1")
+}
 
-            case "${CMD}" in
-                ${CMD_DIG} ) "${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "$1" | grep -om 1 "${REGEX}";;
-                ${CMD_HOST} ) "${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "$1" ${DNSSERVER} | tail -n1 | grep -om 1 "${REGEX}";;
-            esac
-        fi
-    }
-
-    # Result info for IP
-    text() {
-        # IP already?
-        local IP=$(echo "$1" | grep "^${REGEX_IP}$")
-        if [[ -n "${IP}" ]]; then
-            echo "${IP}"
-
-        # Resolve domain
-        else
-
-            local TYPE="txt"
-            case "${CMD}" in
-                ${CMD_DIG} ) "${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "$1" ;;
-                ${CMD_HOST} ) "${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "$1" ${DNSSERVER} | tail -n1 ;;
-            esac
-        fi
-    }
-
-    # Load the blocklist from file
-    loadBlacklists() {
-
-        # Make sure the file is readable
-        if [[ -z "$1" ]]; then
-            error "Option -l requires an additional parameter";
-        elif [[ ! -r $1 ]]; then
-            error "File $1 cannot be opened for reading, make sure it exists and that you have appropriate privileges"
-        fi
-
-        CONF_BLACKLISTS=$(cat "$1")
-    }
-
-    # Show help
-    showHelp() {
-        cat <<HELP
+# Show help
+showHelp() {
+  cat <<HELP
 blcheck [options] <domain_or_IP>
 
 Supplied domain must be full qualified domain name.
@@ -539,51 +603,62 @@ Result of the script is the number of blocklisted entries. So if the supplied
 IP is not blocklisted on any of the servers the result is 0.
 
 HELP
-        exit;
-    }
+  exit
+}
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
 # Parse the params
 while getopts :vqphcl:d: arg; do
-    case "${arg}" in
-        d) DNSSERVER="${OPTARG}";;
-        l) loadBlacklists "${OPTARG}";;
-        c) VERIFY_BL=TRUE;;
-        v) VERBOSE=$((VERBOSE + 1));;
-        q) VERBOSE=-1;;
-        p) PLAIN=1 RED="" GREEN="" YELLOW="" CLEAR="" ;;
-        h) showHelp;;
-        ?) error "Unknown option ${OPTARG}";;
-    esac
+  case "${arg}" in
+  d) DNSSERVER="${OPTARG}" ;;
+  l) loadBlacklists "${OPTARG}" ;;
+  c) VERIFY_BL=TRUE ;;
+  v) VERBOSE=$((VERBOSE + 1)) ;;
+  q) VERBOSE=-1 ;;
+  p) PLAIN=1 RED="" GREEN="" YELLOW="" CLEAR="" ;;
+  h) showHelp ;;
+  ?) error "Unknown option ${OPTARG}" ;;
+  esac
 done
 shift $((OPTIND - 1))
 
 # Get the domain
 if [[ $# -eq 0 ]]; then
-    echo "Missing target domain or IP."
-    showHelp
+  echo "Missing target domain or IP."
+  showHelp
 fi
 TARGET=$1
 
-if [ ! $(which parallel 2> /dev/null) ]; then
-	echo "Parallel missing, trying to install..."
-	if [ $(which yum 2> /dev/null) ]; then
-		[ ! "$(yum -q provides parallel)" ] && yum -y -q install epel-release
-		yum -y -q install parallel
-	elif [ $(which dnf 2> /dev/null) ]; then
-		[ ! "$(dnf -q provides parallel)" ] && dnf -y -q install epel-release
-		dnf -y -q install parallel
-	else #assumed debian-like
-		apt-get -qq update
-		apt-get -y -q install parallel
-	fi
-	if [ "$(which parallel 2> /dev/null)" ]; then
-		mkdir ~/.parallel
-		touch ~/.parallel/will-cite
-	else
-		error "Failed to install parallel, exiting."
-	fi
+BIN_DEPS="ipv6calc dig host"
+for BIN_DEP in $BIN_DEPS; do
+  which "${BIN_DEP}" >/dev/null ||
+    NOT_FOUND="${BIN_DEP} ${NOT_FOUND}"
+done
+
+if [ -n "${NOT_FOUND}" ]; then
+  echo -e "Error: Required program could not be found: ${NOT_FOUND}"
+  exit 1
+fi
+
+if [ ! $(which parallel 2>/dev/null) ]; then
+  echo "Parallel missing, trying to install..."
+  if [ $(which yum 2>/dev/null) ]; then
+    [ ! "$(yum -q provides parallel)" ] && yum -y -q install epel-release
+    yum -y -q install parallel
+  elif [ $(which dnf 2>/dev/null) ]; then
+    [ ! "$(dnf -q provides parallel)" ] && dnf -y -q install epel-release
+    dnf -y -q install parallel
+  else #assumed debian-like
+    apt-get -qq update
+    apt-get -y -q install parallel
+  fi
+  if [ "$(which parallel 2>/dev/null)" ]; then
+    mkdir ~/.parallel
+    touch ~/.parallel/will-cite
+  else
+    error "Failed to install parallel, exiting."
+  fi
 fi
 
 # Some shells disable parsing backslash in echo statements by default
@@ -592,61 +667,66 @@ shopt -s xpg_echo
 
 # Get the command we will use: dig or host
 CMD_DIG=$(which dig)
-if [[ "${CMD_DIG}" ]]; then
-    if [[ -n "${DNSSERVER}" ]]; then
-        DNSSERVER="@${DNSSERVER}"
-    fi
-    CMD=${CMD_DIG}
+if [[ -n "${CMD_DIG}" ]]; then
+  if [[ -n "${DNSSERVER}" ]]; then
+    DNSSERVER="@${DNSSERVER}"
+  fi
+  CMD=${CMD_DIG}
 else
-    CMD_HOST=$(which host)
-    if [[ "${CMD_HOST}" ]]; then
-        CMD=${CMD_HOST}
-    fi
+  CMD_HOST=$(which host)
+  if [[ -n "${CMD_HOST}" ]]; then
+    CMD=${CMD_HOST}
+  fi
 fi
 if [[ -z "${CMD}" ]]; then
-    error "Either dig or host command is required."
+  error "Either dig or host command is required."
 fi
-info 3 "Using ${CMD} to reslove DNS queries"
+info 3 "Using ${CMD} to resolve DNS queries"
 
 # Parse IP
 IP=$(resolve "${TARGET}")
 if [[ -z "${IP}" ]]; then
-    error "No DNS record found for ${TARGET}"
+  error "No DNS record found for ${TARGET}"
 elif [[ "${IP}" != "${TARGET}" ]]; then
-    DOMAIN=${TARGET}
-    info 2 "Using ${TARGET} for target, resolved to ${IP}"
-    TARGET_TYPE="domain"
+  DOMAIN=${TARGET}
+  info 2 "Using ${TARGET} for target, resolved to ${IP}"
+  TARGET_TYPE="domain"
 else
-    info 3 "Using ${TARGET} for target"
-    TARGET_TYPE="ip"
+  info 3 "Using ${TARGET} for target"
+  TARGET_TYPE="ip"
 fi
 
 # Reverse the IP
-REVERSED=$(echo "${IP}" | sed -ne "s~^${REGEX_IP}$~\4.\3.\2.\1~p")
+if ipv6calc -qI ipv6addr "${IP}" &>/dev/null; then
+  REVERSED=$(reverseIPv6 "${IP}")
+else
+  REVERSED=$(reverseIPv4 "${IP}")
+fi
+
 info 3 "Using ${REVERSED} for reversed IP"
 
 # Get the PTR
 info 3 "Checking the PTR record"
 case "${CMD}" in
-    ${CMD_DIG} ) PTR=$("${CMD}" ${DNSSERVER} +short -x "${IP}" | sed s/\.$//);;
-    ${CMD_HOST} ) PTR=$("${CMD}" "${IP}" ${DNSSERVER} | tail -n1 | grep -o '[^ ]\+$' | sed s/\.$//)
+"${CMD_DIG}") PTR=$("${CMD}" ${DNSSERVER} +short -x "${IP}" | sed s/\.$//) ;;
+"${CMD_HOST}") PTR=$("${CMD}" "${IP}" ${DNSSERVER} | tail -n1 | grep -o '[^ ]\+$' | sed s/\.$//) ;;
 esac
 
 # Validate PTR
 if [[ -z "${PTR}" ]]; then
-    info 0 "${YELLOW}Warning: PTR lookup failed${CLEAR}"
+  info 0 "${YELLOW}Warning: PTR lookup failed${CLEAR}"
 
 else
 
-    # Match against supplied domain
-    info 1 "PTR resolves to ${PTR}"
-    if [[ -n "${DOMAIN}" ]]; then
-        if [[ "${DOMAIN}" != "${PTR}" ]]; then
-            info 0 "${YELLOW}Warning: PTR record does not match supplied domain: ${TARGET} != ${PTR}${CLEAR}"
-        else
-            info 1 "${GREEN}PTR record matches supplied domain ${PTR}${CLEAR}"
-        fi
+  # Match against supplied domain
+  info 1 "PTR resolves to ${PTR}"
+  if [[ -n "${DOMAIN}" ]]; then
+    if [[ "${DOMAIN}" != "${PTR}" ]]; then
+      info 0 "${YELLOW}Warning: PTR record does not match supplied domain: ${TARGET} != ${PTR}${CLEAR}"
+    else
+      info 1 "${GREEN}PTR record matches supplied domain ${PTR}${CLEAR}"
     fi
+  fi
 fi
 
 # Filter out the blocklists
@@ -656,53 +736,53 @@ COUNT_DNSWL=0
 COUNT_URIBL=0
 COUNT=0
 for BL in ${CONF_BLACKLISTS}; do
-    if [[ "${BL}" ]]; then
-        if [[ ${BL} =~ ${REGEX_LIST} ]]; then
-            DOMAIN="${BASH_REMATCH[1]}"
-            if [[ -n "${BASH_REMATCH[3]}" ]]; then
-                FILTER="${BASH_REMATCH[3]}"
-            else
-                FILTER='127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})'
-            fi
-            if [[ -n "${BASH_REMATCH[6]}" ]]; then
-                TYPE="${BASH_REMATCH[6]}"
-            else
-                TYPE='DNSBL'
-            fi
+  if [[ "${BL}" ]]; then
+    if [[ ${BL} =~ ${REGEX_LIST} ]]; then
+      DOMAIN="${BASH_REMATCH[1]}"
+      if [[ -n "${BASH_REMATCH[3]}" ]]; then
+        FILTER="${BASH_REMATCH[3]}"
+      else
+        FILTER='127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})'
+      fi
+      if [[ -n "${BASH_REMATCH[6]}" ]]; then
+        TYPE="${BASH_REMATCH[6]}"
+      else
+        TYPE='DNSBL'
+      fi
 
-            # Make sure the domain is a proper one
-            TMP=$(echo "${DOMAIN}" | sed -e 's/^[ \t]*//' | grep ^"${REGEX_DOMAIN}"$)
-            if [[ -z "${TMP}" ]]; then
-               info 0 "${YELLOW}Warning: domain '${DOMAIN}' is not valid and will be ignored${CLEAR}"
+      # Make sure the domain is a proper one
+      TMP=$(echo "${DOMAIN}" | sed -e 's/^[ \t]*//' | grep ^"${REGEX_DOMAIN}"$)
+      if [[ -z "${TMP}" ]]; then
+        info 0 "${YELLOW}Warning: domain '${DOMAIN}' is not valid and will be ignored${CLEAR}"
 
-            else
-                if [[ "${TARGET_TYPE}" == 'ip' && "${TYPE}" == 'URIBL' ]]; then
-                    info 0 "${GREEN}Notice: URIBL entry '${DOMAIN}' will be ignore, because ${TARGET} is an IP address${CLEAR}"
-                else
-                case "${TYPE}" in
-                    "DNSBL") COUNT_DNSBL=$((COUNT_DNSBL + 1)) ;;
-                    "DNSWL") COUNT_DNSWL=$((COUNT_DNSWL + 1)) ;;
-                    "URIBL") COUNT_URIBL=$((COUNT_URIBL + 1)) ;;
-                esac
-                COUNT=$((COUNT + 1))
-
-                # It is a proper blocklist
-                if [[ "${BLACKLISTS}" ]]; then
-                    BLACKLISTS=$(echo "${BLACKLISTS}\n${DOMAIN}=${FILTER}#${TYPE}")
-                else
-                    BLACKLISTS="${DOMAIN}=${FILTER}#${TYPE}"
-                fi
-            fi
-            fi
+      else
+        if [[ "${TARGET_TYPE}" == 'ip' && "${TYPE}" == 'URIBL' ]]; then
+          info 0 "${GREEN}Notice: URIBL entry '${DOMAIN}' will be ignore, because ${TARGET} is an IP address${CLEAR}"
         else
-            info 0 "${YELLOW}Warning: list entry '${BL}' is not valid and will be ignored${CLEAR}"
+          case "${TYPE}" in
+          "DNSBL") COUNT_DNSBL=$((COUNT_DNSBL + 1)) ;;
+          "DNSWL") COUNT_DNSWL=$((COUNT_DNSWL + 1)) ;;
+          "URIBL") COUNT_URIBL=$((COUNT_URIBL + 1)) ;;
+          esac
+          COUNT=$((COUNT + 1))
+
+          # It is a proper blocklist
+          if [[ "${BLACKLISTS}" ]]; then
+            BLACKLISTS=$(echo -e "${BLACKLISTS}\n${DOMAIN}=${FILTER}#${TYPE}")
+          else
+            BLACKLISTS="${DOMAIN}=${FILTER}#${TYPE}"
+          fi
         fi
+      fi
+    else
+      info 0 "${YELLOW}Warning: list entry '${BL}' is not valid and will be ignored${CLEAR}"
     fi
+  fi
 done
 
 # Make sure we have at least one blocklist
 if [[ "${COUNT}" -eq 0 ]]; then
-    error "No blocklists have been specified"
+  error "No blocklists have been specified"
 fi
 info 1 "Matching against ${COUNT} entries:"
 info 1 "  - ${COUNT_DNSBL} DNS blocklists"
@@ -712,158 +792,184 @@ info 1 "  - ${COUNT_URIBL} URI blocklists"
 # Iterate over all blocklists
 
 parallel_check() {
-    local PREFIX=
-    local I=$1
-    local BL=$2
+  local PREFIX=
+  local I=$1
+  local BL=$2
 
-    # Parse list entry
-    if [[ ! ${BL} =~ ${REGEX_LIST} ]]; then
-        error "List entry ${BL} broken"
+  # Parse list entry
+  if [[ ! ${BL} =~ ${REGEX_LIST} ]]; then
+    error "List entry ${BL} broken"
+  else
+    local DOMAIN="${BASH_REMATCH[1]}"
+    local FILTER="${BASH_REMATCH[3]}"
+    local TYPE="${BASH_REMATCH[6]}"
+  fi
+
+  # What should we test
+  if [[ "${TYPE}" != "URIBL" ]]; then
+    # IP based test
+    local TEST="${REVERSED}.${DOMAIN}."
+  else
+    # Domain name based test (URI)
+    local TEST="${TARGET}.${DOMAIN}."
+  fi
+
+  # Make sure the info is shown if we are checking the servers
+  if [[ "${VERIFY_BL}" && "${VERBOSE}" -lt 1 ]]; then
+    local VERBOSE=1
+  fi
+
+  # For verbose output
+  if [[ "${VERBOSE}" -ge 1 ]]; then
+    local STATUS
+    # Show percentage
+    STATUS=$(printf " %3s" $((I * 100 / COUNT)))
+    STATUS="${STATUS}% "
+
+    # Show additional info
+    if [[ "${VERBOSE}" -ge 3 ]]; then
+      PREFIX=$(printf "%-60s" "${TEST}")
     else
-        local DOMAIN="${BASH_REMATCH[1]}"
-        local FILTER="${BASH_REMATCH[3]}"
-        local TYPE="${BASH_REMATCH[6]}"
+      PREFIX=$(printf "%-50s" "${DOMAIN}")
     fi
 
-
-
-    # What should we test
-    if [[ "${TYPE}" != "URIBL" ]]; then
-        # IP based test
-        local TEST="${REVERSED}.${DOMAIN}."
-    else
-        # Domain name based test (URI)
-        local TEST="${TARGET}.${DOMAIN}."
+    PREFIX="${STATUS} ${PREFIX}"
+    if [[ -z "${PLAIN}" ]]; then
+      printf "%s \b" "${PREFIX}"
     fi
 
+  elif [[ "${VERBOSE}" -ge 0 ]]; then
+    if [[ -z "${PLAIN}" ]]; then
+      progress "${I}" "${COUNT}"
+    fi
+  fi
 
-    # Make sure the info is shown if we are checking the servers
-    if [[ "${VERIFY_BL}" && "${VERBOSE}" -lt 1 ]]; then
-        local VERBOSE=1
+  # Get the status
+  local RESPONSE=$(resolve "${TEST}")
+
+  # Not blocklisted
+  if [[ -z "${RESPONSE}" ]]; then
+
+    # Make sure the server is viable
+    local ERROR=""
+    if [[ "${VERIFY_BL}" ]]; then
+      local TDL
+      TDL=$(echo "${DOMAIN}" | grep -om 1 '\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$')
+      if [[ ! "$(resolve "${TDL}" ns)" ]]; then
+        if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+        printf "%s%sUnreachable server%s\n" "${YELLOW}" "${PREFIX}" "${CLEAR}"
+        echo "$BL" | cut -d= -f1 >>"${INVALID_FILE}"
+        ERROR=TRUE
+      fi
     fi
 
-    # For verbose output
+    if [[ ! "${ERROR}" ]]; then
+      if [[ -n "${VERIFY_BL}" || "${VERBOSE}" -ge 1 ]]; then
+        if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+        printf "%s%s✓%s\n" "${CLEAR}" "${PREFIX}" "${CLEAR}"
+      fi
+      echo "$BL" | cut -d= -f1 >>"${PASSED_FILE}"
+    fi
+
+  # Invalid response
+  elif [[ ! "${RESPONSE}" =~ ${FILTER} ]]; then
     if [[ "${VERBOSE}" -ge 1 ]]; then
-
-        # Show percentage
-        local STATUS=$(printf " %3s" $((I * 100 / COUNT)))
-        STATUS="${STATUS}% "
-
-        # Show additional info
-        if [[ "${VERBOSE}" -ge 3 ]]; then
-            PREFIX=$(printf "%-60s" "${TEST}")
-        else
-            PREFIX=$(printf "%-50s" "${DOMAIN}")
-        fi
-
-        PREFIX="${STATUS} ${PREFIX}"
-        if [[ -z "${PLAIN}" ]]; then
-            printf "%s \b" "${PREFIX}"
-        fi
-
-    elif [[ "${VERBOSE}" -ge 0 ]]; then
-        if [[ -z "${PLAIN}" ]]; then
-            progress "${I}" "${COUNT}"
-        fi
+      if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+      printf "%s%sinvalid response (%s)%s\n" "${YELLOW}" "${PREFIX}" "${RESPONSE}" "${CLEAR}"
+      printf "%s%${#PREFIX}s%s%s\n" "${YELLOW}" "TXT: " "$(text "${TEST}")" "${CLEAR}"
     fi
+    echo "$BL" | cut -d= -f1 >>"${INVALID_FILE}"
 
-    # Get the status
-    local RESPONSE=$(resolve "${TEST}")
-
-    # Not blocklisted
-    if [[ -z "${RESPONSE}" ]]; then
-
-        # Make sure the server is viable
-        local ERROR=""
-        if [[ "${VERIFY_BL}" ]]; then
-            local TDL=$(echo "${DOMAIN}" | grep -om 1 '\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$')
-            if [[ ! "$(resolve "${TDL}" ns)" ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
-                printf "%s%sUnreachable server%s\n" "${YELLOW}" "${PREFIX}" "${CLEAR}";
-                echo "$BL" | cut -d= -f1 >> $invalid_file
-                ERROR=TRUE
-            fi
+  # matched
+  else
+    if [[ "${TYPE}" != "DNSWL" ]]; then
+      if [[ "${VERBOSE}" -ge 1 ]]; then
+        if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+        printf "%s%sblocklisted (%s)%s\n" "${RED}" "${PREFIX}" "${RESPONSE}" "${CLEAR}"
+        printf "%s%${#PREFIX}s%s%s\n" "${RED}" "TXT: " "$(text "${TEST}")" "${CLEAR}"
+      elif [[ "${VERBOSE}" -ge 0 ]]; then
+        if [[ -z "${PLAIN}" ]]; then
+          printf "\r                                                          "
+          printf "\r"
         fi
-
-        if [[ ! "${ERROR}" ]]; then
-            if [[ -n "${VERIFY_BL}" || "${VERBOSE}" -ge 1 ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
-                printf "%s%s✓%s\n" "${CLEAR}" "${PREFIX}" "${CLEAR}";
-            fi
-            echo "$BL" | cut -d= -f1 >> $passed_file
-        fi;
-
-    # Invalid response
-    elif [[ ! "${RESPONSE}" =~ ${FILTER} ]]; then
-        if [[ "${VERBOSE}" -ge 1 ]]; then
-            if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
-            printf "%s%sinvalid response (%s)%s\n" "${YELLOW}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
-            printf "%s%${#PREFIX}s%s%s\n" "${YELLOW}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
-        fi;
-        echo "$BL" | cut -d= -f1 >> $invalid_file
-
-    # matched
+        printf "%s%s%s : %s\n" "${RED}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
+      fi
+      echo "$BL" | cut -d= -f1 >>"${FAILED_FILE}"
     else
-        if [[ "${TYPE}" != "DNSWL" ]]; then
-            if [[ "${VERBOSE}" -ge 1 ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
-                printf "%s%sblocklisted (%s)%s\n" "${RED}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
-                printf "%s%${#PREFIX}s%s%s\n" "${RED}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
-            elif [[ "${VERBOSE}" -ge 0 ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r                                                          "; printf "\r"; fi
-                printf "%s%s%s : %s\n" "${RED}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
-            fi
-            echo "$BL" | cut -d= -f1 >> $failed_file
-        else
-            if [[ "${VERBOSE}" -ge 1 ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
-                printf "%s%sallowlisted (%s)%s\n" "${GREEN}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
-                printf "%s%${#PREFIX}s%s%s\n" "${GREEN}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
-            elif [[ "${VERBOSE}" -ge 0 ]]; then
-                if [[ -z "${PLAIN}" ]]; then printf "\r                                                          "; printf "\r"; fi
-                printf "%s%s%s : %s\n" "${GREEN}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
-            fi
-             echo "$BL" | cut -d= -f1 >> $allow_file
+      if [[ "${VERBOSE}" -ge 1 ]]; then
+        if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+        printf "%s%sallowlisted (%s)%s\n" "${GREEN}" "${PREFIX}" "${RESPONSE}" "${CLEAR}"
+        printf "%s%${#PREFIX}s%s%s\n" "${GREEN}" "TXT: " "$(text "${TEST}")" "${CLEAR}"
+      elif [[ "${VERBOSE}" -ge 0 ]]; then
+        if [[ -z "${PLAIN}" ]]; then
+          printf "\r                                                          "
+          printf "\r"
         fi
+        printf "%s%s%s : %s\n" "${GREEN}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
+      fi
+      echo "$BL" | cut -d= -f1 >>"${ALLOW_FILE}"
     fi
+  fi
 }
 
-allow_file=$(mktemp)
-failed_file=$(mktemp)
-passed_file=$(mktemp)
-invalid_file=$(mktemp)
+# Create temporary files
+ALLOW_FILE=$(mktemp)
+FAILED_FILE=$(mktemp)
+PASSED_FILE=$(mktemp)
+INVALID_FILE=$(mktemp)
+
+# Export functions
 export -f parallel_check resolve text progress
-export REGEX_LIST REVERSED TARGET VERIFY_BL VERBOSE PLAIN COUNT YELLOW CLEAR RED GREEN SPINNER REGEX_IP REGEX_DOMAIN CMD_DIG DNSSERVER CONF_DNS_DURATION CONF_DNS_TRIES REGEX CMD_HOST CMD allow_file failed_file passed_file invalid_file
-parallel -j $j 'parallel_check {#} {}' ::: ${BLACKLISTS}
+
+# Export variables
+export REGEX_LIST REVERSED TARGET VERIFY_BL VERBOSE PLAIN \
+  COUNT YELLOW CLEAR RED GREEN SPINNER REGEX_IP REGEX_DOMAIN \
+  CMD_DIG DNSSERVER CONF_DNS_DURATION CONF_DNS_TRIES REGEX \
+  CMD_HOST CMD ALLOW_FILE FAILED_FILE PASSED_FILE INVALID_FILE
+
+# Use parallel, call the function parallel_check
+# -j = an option to run parallel job
+# {#} = this means it will take the real job number as the first argument
+# {} = this will pass the the blacklist entries that will be obtained from BLACKLISTS after symbol :::
+#      this is used to display the blacklist entry
+parallel -j ${PARALLEL_JOB} 'parallel_check {#} {}' ::: "${BLACKLISTS}"
 
 # Print results
 if [[ "${VERBOSE}" -ge 0 ]]; then
-    if [[ -z "${PLAIN}" ]]; then
-        printf "\r                                                    \n"
-    else
-        printf "                                                     \n"
-    fi
-    echo "----------------------------------------------------------"
-    echo Results for "${TARGET}"
-    echo
-    printf "%-15s" "Tested:";   echo "${COUNT}"
-    printf "%-15s" "Passed:";   echo "${GREEN}$(cat $passed_file | wc -l)${CLEAR}"
-    printf "%-15s" "Whitelisted:";  echo "${GREEN}$(cat $allow_file | wc -l)${CLEAR}"
-    printf "%-15s" "Invalid:";  echo "${YELLOW}$(cat $invalid_file | wc -l)${CLEAR}"
-    printf "%-15s" "Blacklisted:";  echo "${RED}$(cat $failed_file | wc -l)${CLEAR}"
-    echo "----------------------------------------------------------"
+  if [[ -z "${PLAIN}" ]]; then
+    printf "\r                                                    \n"
+  else
+    printf "                                                     \n"
+  fi
+  echo "----------------------------------------------------------"
+  echo Results for "${TARGET}"
+  echo
+  printf "%-15s" "Tested:"
+  echo "${COUNT}"
+  printf "%-15s" "Passed:"
+  echo "${GREEN}$(wc -l < "${PASSED_FILE}")${CLEAR}"
+  printf "%-15s" "Whitelisted:"
+  echo "${GREEN}$(wc -l < "${ALLOW_FILE}")${CLEAR}"
+  printf "%-15s" "Invalid:"
+  echo "${YELLOW}$(wc -l < "${INVALID_FILE}")${CLEAR}"
+  printf "%-15s" "Blacklisted:"
+  echo "${RED}$(wc -l < "${FAILED_FILE}")${CLEAR}"
+  echo "----------------------------------------------------------"
 fi
 
-failed=$(cat $failed_file | wc -l)
-if [ $failed -gt 0 ]; then
-	touch $output
-	echo ${TARGET} >> $output
-	cat $failed_file >> $output
+FAILED_COUNT=$(wc -l <"${FAILED_FILE}")
+
+if [[ ${FAILED_COUNT} -gt 0 ]]; then
+  touch "${OUTPUT}"
+  echo ${TARGET} >>"${OUTPUT}"
+  cat "${FAILED_FILE}" >>"${OUTPUT}"
 fi
 
-rm -f $passed_file $allow_file $invalid_file $failed_file
-
+rm -f "${PASSED_FILE}" "${ALLOW_FILE}" "${INVALID_FILE}" "${FAILED_FILE}"
 unset -f parallel_check resolve text progress
-unset REGEX_LIST REVERSED TARGET VERIFY_BL VERBOSE PLAIN COUNT YELLOW CLEAR RED GREEN SPINNER REGEX_IP REGEX_DOMAIN CMD_DIG DNSSERVER CONF_DNS_DURATION CONF_DNS_TRIES REGEX CMD_HOST CMD allow_file failed_file passed_file invalid_file
+unset REGEX_LIST REVERSED TARGET VERIFY_BL VERBOSE PLAIN \
+COUNT YELLOW CLEAR RED GREEN SPINNER REGEX_IP REGEX_DOMAIN \
+CMD_DIG DNSSERVER CONF_DNS_DURATION CONF_DNS_TRIES REGEX \
+CMD_HOST CMD ALLOW_FILE FAILED_FILE PASSED_FILE INVALID_FILE
 
-exit "${failed}"
+exit "${FAILED_COUNT}"


### PR DESCRIPTION
Added IPv6 support (required ipv6calc package)

In the previous version, you could not check the IP addresses with IPv6 format or host that resolves to only IPv6 AAAA record (eg: ipv6.google.com). Now you can do this:

blcheck 2604:a880:800:a1:0:0:456:5001

blcheck 2404:6800:4003:0c06:0000:0000:0000:0071

blcheck ipv6.google.com